### PR TITLE
Add 'open' keyword to Bender core classes to extend outside the module

### DIFF
--- a/Bender/ArrayRule.swift
+++ b/Bender/ArrayRule.swift
@@ -32,7 +32,7 @@ import Foundation
 /**
  Validator for arrays of items of type T, that should be validated by rule of type R, i.e. where R.V == T.
  */
-public class ArrayRule<T, R: Rule>: Rule where R.V == T {
+open class ArrayRule<T, R: Rule>: Rule where R.V == T {
     public typealias V = [T]
     
     typealias ValidateClosure = (AnyObject) throws -> T

--- a/Bender/EnumRule.swift
+++ b/Bender/EnumRule.swift
@@ -33,7 +33,7 @@ import Foundation
  Validator for enum of type T. Checks that JSON value to be validated is equal to any option stored and .
  If all stored properties do not match, throws ValidateError.
  */
-public class EnumRule<T: Equatable>: Rule {
+open class EnumRule<T: Equatable>: Rule {
     public typealias V = T
     
     fileprivate var cases: [(AnyObject) throws -> T?] = []

--- a/Bender/ObjectRule.swift
+++ b/Bender/ObjectRule.swift
@@ -33,7 +33,7 @@ import Foundation
  Validator for compound types: classes or structs. Validates JSON struct for particular type T,
  which is passed by value of type RefT.
  */
-public class ObjectRule<T, RefT>: Rule {
+open class ObjectRule<T, RefT>: Rule {
     public typealias V = T
     
     fileprivate typealias LateBindClosure = (RefT) -> Void
@@ -400,7 +400,7 @@ public class ObjectRule<T, RefT>: Rule {
 /**
  Validator of compound JSON object with binding to reference type like class T. Reference type is T itself.
  */
-public class ClassRule<T>: ObjectRule<T, T> {
+open class ClassRule<T>: ObjectRule<T, T> {
     
     public override init( _ factory: @autoclosure @escaping ()->T) {
         super.init(factory)
@@ -414,7 +414,7 @@ public class ClassRule<T>: ObjectRule<T, T> {
 /**
  Validator of compound JSON object with binding to value type like struct T. Reference type is ref<T>.
  */
-public class StructRule<T>: ObjectRule<T, ref<T>> {
+open class StructRule<T>: ObjectRule<T, ref<T>> {
     
     public override init( _ factory: @autoclosure @escaping ()->ref<T>) {
         super.init(factory)

--- a/Bender/StringifiedJSONRule.swift
+++ b/Bender/StringifiedJSONRule.swift
@@ -32,7 +32,7 @@ import Foundation
 /**
  Validator of JSON encoded into string like this: "\"field": \"value\"". Encoded JSON should be validated by given rule of type R.
  */
-public class StringifiedJSONRule<R: Rule>: Rule {
+open class StringifiedJSONRule<R: Rule>: Rule {
     public typealias V = R.V
     
     fileprivate let nestedRule: R

--- a/Bender/TypeRule.swift
+++ b/Bender/TypeRule.swift
@@ -32,7 +32,7 @@ import Foundation
 /**
  Base class for numeric validators
  */
-public class NumberRule<T>: Rule {
+open class NumberRule<T>: Rule {
     public typealias V = T
     
     public func validate(_ jsonValue: AnyObject) throws -> T {
@@ -42,11 +42,11 @@ public class NumberRule<T>: Rule {
         return try validateNumber(number)
     }
     
-    public func dump(_ value: T) throws -> AnyObject {
+    open func dump(_ value: T) throws -> AnyObject {
         return try toAny(value)
     }
     
-    public func validateNumber(_ number: NSNumber) throws -> T {
+    open func validateNumber(_ number: NSNumber) throws -> T {
         throw RuleError.invalidJSONType("Value of unexpected type found: \"\(number)\". Expected \(T.self).", nil)
     }
 }


### PR DESCRIPTION
Some methods (like validate and dump) are marked as 'open' but class owners have 'public' keyword. According to documentation:
- An open class is accessible and subclassable outside of the defining module. An open class member is accessible and overridable outside of the defining module.
- A public class is accessible but not subclassable outside of the defining module. A public class member is accessible but not overridable outside of the defining module.

So to extend Bender core classes outside the module we need to change keyword to 'open'.